### PR TITLE
remote: now list remotes along with the details about capacity.

### DIFF
--- a/ksau
+++ b/ksau
@@ -447,7 +447,10 @@ elif [[ $1 == "update" ]]; then
 elif [[ $1 == "version" ]]; then
     version
 elif [[ $1 == "list" ]]; then
-    printf 'Remote: %s\n' "${REMOTES[@]}"
+    for remote in "${REMOTES[@]}"; do
+        remote_about=$(rclone about ${remote}:)
+        printf '%sRemote: %s%s\n%s%s%s\n\n' "${orange}" "${remote}" "${normal}" "${aqua}" "${remote_about}" "${normal}"
+    done
 elif [[ $1 == "help" ]]; then
     help
 elif [[ $1 == "" ]]; then


### PR DESCRIPTION
Now list function will display information about the remotes too.

```bash
ksauraj on Xenon-ⲕꜱᵃᵘ global_index_source on  devel took 23ms 
 ﬌ ksau list
Using cached remote with most free space: hakimionedrive
Remote: oned
Total:   5 TiB
Used:    4.234 TiB
Free:    629.471 GiB
Trashed: 154.939 GiB

Remote: hakimionedrive
Total:   5 TiB
Used:    41.008 GiB
Free:    4.960 TiB
Trashed: 0 B

Remote: saurajcf
Total:   5 TiB
Used:    536.356 GiB
Free:    4.472 TiB
Trashed: 4.737 GiB

```

Current Challenges :
- Execution time is high.

Expected Improvements : 
- Add a progress bar for available space
- Reducing execution time ( might be challenging ).
